### PR TITLE
fix: broken "Troubleshooting" link

### DIFF
--- a/dashboard/src/App.js
+++ b/dashboard/src/App.js
@@ -18,7 +18,7 @@ function App() {
                 <div className="wrapper">
                     <p>
                         {'Blackfire Go Probe Dashboard version experimental - '}
-                        <a href="https://blackfire.io/docs/troubleshooting">{'Troubleshooting'}</a>
+                        <a href="https://support.blackfire.io/en/collections/145104-troubleshooting">{'Troubleshooting'}</a>
                     </p>
                 </div>
             </footer>


### PR DESCRIPTION
Fix a broken link in the dashboard